### PR TITLE
Change custom policy documents in getPrivateUrl to be base64-encoded

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -584,7 +584,7 @@ CloudFront.prototype.getPrivateUrl = function(a, b, c, d) {
   };
 
   if (custom) {
-    query["Policy"] = policy.replace(/\+/g, '-').replace(/\=/g, '_').replace(/\//g, '~');
+    query["Policy"] = new Buffer(policy).toString('base64');
   } else {
     query["Expires"] = config.expires;
   }


### PR DESCRIPTION
Hi, I noticed that AWS rejects URL's generated by getPrivateUrl when custom policy parameters are used, such as 'IpAddress'.

It looks like the policy document is supposed to be encoded in base64 prior to being added to the URL (which makes sense). The documentation is actually pretty vague on this, but the PHP code example clearly shows this happening:

..
$canned_policy = '{"Statement":[{"Resource":"' . $video_path . '","Condition":{"DateLessThan":{"AWS:EpochTime":'. $expires . '}}}]}';
    // the policy contains characters that cannot be part of a URL, 
    // so we Base64 encode it
    $encoded_policy = url_safe_base64_encode($canned_policy);
..

http://docs.amazonwebservices.com/AmazonCloudFront/latest/DeveloperGuide/CreateURL_PHP.html

Let me know if there's a better way to implement this (small) change, thanks.
